### PR TITLE
V1.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Change Log - Procedural 3D Dungeon Generator Plug-in
 
-## 20250722-1.7.4 (57)
+## 20250823-1.7.5 (58)
+### Changes
+* Enable/disable control of shadow generation in point light derived classes changed from per-partition to per-light.
+* Fixed several bugs
+### 変更点
+* ポイントライト派生クラスの影の生成の有効無効制御をパーティエーション単位からライト単位に変更
+* いくつかの不具合を修正
+
+## 202500809-1.7.4 (57)
 ### Changes
 * Fixed several bugs
 ### 変更点
 * いくつかの不具合を修正
 
-## 20250722-1.7.3 (56)
+## 202500807-1.7.3 (56)
 ### Changes
 * Added widget class to assist in creating mini-maps
 * Adjusted the effective range of point light and spot light shadows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## 20250823-1.7.5 (58)
 ### Changes
 * Enable/disable control of shadow generation in point light derived classes changed from per-partition to per-light.
+* Added actors that regularly spawn actors.
 * Fixed several bugs
 ### 変更点
 * ポイントライト派生クラスの影の生成の有効無効制御をパーティエーション単位からライト単位に変更
+* アクターを定期的にスポーンするアクターを追加
 * いくつかの不具合を修正
 
 ## 202500809-1.7.4 (57)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Change Log - Procedural 3D Dungeon Generator Plug-in
 
-## 20250823-1.7.5 (58)
+## 20250831-1.7.5 (58)
 ### Changes
 * Enable/disable control of shadow generation in point light derived classes changed from per-partition to per-light.
+* Fixed a misjudgment of the viewing cone in the determination of active partition.
+* Limit the transfer method of the minimap to only the area of the change.
 * Added actors that regularly spawn actors.
 * Fixed several bugs
 ### 変更点
 * ポイントライト派生クラスの影の生成の有効無効制御をパーティエーション単位からライト単位に変更
+* アクティブパーティエーションの判定で視錐台の判定ミスを修正
+* ミニマップの転送方法を変更範囲のみに限定
 * アクターを定期的にスポーンするアクターを追加
 * いくつかの不具合を修正
 

--- a/DungeonGenerator.uplugin
+++ b/DungeonGenerator.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 57,
-	"VersionName": "1.7.4",
+	"Version": 58,
+	"VersionName": "1.7.5",
 	"FriendlyName": "Dungeon Generator",
 	"Description": "Procedural 3d dungeon generator plugin. Easy generation of levels, mini-maps and missions.",
 	"Category": "Procedural Systems",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/shun126/UE5-DungeonGeneratorDemo/issues">Issues</a>,
 <a href="https://github.com/shun126/UE5-DungeonGeneratorDemo/discussions">Discussions</a>,
 <a href="https://github.com/shun126/UE5-DungeonGeneratorDemo/wiki">Wiki</a>,
-<a href="https://mnu.sakura.ne.jp/_doxygen/dungeon_generator">Doxygen</a>
+<a href="https://happy-game-dev.undo.jp/_doxygen/dungeon_generator/index.html">Doxygen</a>
 </p>
 </div>
 
@@ -82,7 +82,7 @@ Or, [Fab](https://fab.com/s/f5587c55bad0) is releasing it under Epic license. If
 # 👀 See also
 * [Wiki](https://github.com/shun126/UE5-DungeonGeneratorDemo/wiki)
 * [DeepWiki](https://deepwiki.com/shun126/DungeonGenerator)
-* [Doxygen](https://mnu.sakura.ne.jp/_doxygen/dungeon_generator/)
+* [Doxygen](https://happy-game-dev.undo.jp/_doxygen/dungeon_generator/index.html)
 * [Issues](https://github.com/shun126/UE5-DungeonGeneratorDemo/issues)
 * [Discussions](https://github.com/shun126/UE5-DungeonGeneratorDemo/discussions)
 

--- a/Source/DungeonGenerator/DungeonGenerator.Build.cs
+++ b/Source/DungeonGenerator/DungeonGenerator.Build.cs
@@ -21,32 +21,33 @@ public class DungeonGenerator : ModuleRules
 			new string[]
 			{
 			});
-		*/
 		PublicDependencyModuleNames.AddRange(
 			new string[]
 			{
-				"Core",
-                "AIModule"
-            });
+			});
+		*/
 
 		PrivateDependencyModuleNames.AddRange(
 			new string[]
 			{
+				"Core",
 				"CoreUObject",
 				"Engine",
+				"AIModule",
 				"NavigationSystem",
-                "NetCore",
+				"NetCore",
 				"SlateCore",
 				"UMG",
-                "Foliage"
-            });
+				"Foliage",
+			}
+		);
 		if (Target.bBuildEditor)
 		{
 			PrivateDependencyModuleNames.AddRange(
 				new string[] {
 					"UnrealEd",
-	                "JsonUtilities",
-                });
+					"JsonUtilities",
+				});
 		}
 
 		/*

--- a/Source/DungeonGenerator/Private/Core/Generator.cpp
+++ b/Source/DungeonGenerator/Private/Core/Generator.cpp
@@ -1620,6 +1620,7 @@ namespace dungeon
 				switch (mVoxel->Get(location).GetType())
 				{
 				case Grid::Type::Slope:
+				case Grid::Type::DownSpace:
 				case Grid::Type::StructuralColumn:
 					return false;
 

--- a/Source/DungeonGenerator/Private/Core/Generator.cpp
+++ b/Source/DungeonGenerator/Private/Core/Generator.cpp
@@ -1533,13 +1533,17 @@ namespace dungeon
 		const int32 minZ = room->GetBackground();
 		const int32 maxZ = room->GetForeground();
 
-		const int32 count = room->GetRect().Area() / 8;
-		for (int32 i = 0; i < count; ++i)
+		int32 count = static_cast<int32>(std::sqrt(static_cast<float>(room->GetRect().Area())));
+		if (count >= 5)
 		{
-			const int32 x = mGenerateParameter.GetRandom()->Get(room->GetLeft(), room->GetRight());
-			const int32 y = mGenerateParameter.GetRandom()->Get(room->GetTop(), room->GetBottom());
-			if (CanFillStructuralColumnVoxel(x, y, minZ, maxZ))
-				FillStructuralColumnVoxel(x, y, minZ, maxZ);
+			count /= 2;
+			for (int32 i = 0; i < count; ++i)
+			{
+				const int32 x = mGenerateParameter.GetRandom()->Get(room->GetLeft(), room->GetRight());
+				const int32 y = mGenerateParameter.GetRandom()->Get(room->GetTop(), room->GetBottom());
+				if (CanFillStructuralColumnVoxel(x, y, minZ, maxZ))
+					FillStructuralColumnVoxel(x, y, minZ, maxZ);
+			}
 		}
 
 		if (mGenerateParameter.GetRandom()->Get(3) == 0)

--- a/Source/DungeonGenerator/Private/Core/Helper/DrawLots.h
+++ b/Source/DungeonGenerator/Private/Core/Helper/DrawLots.h
@@ -13,9 +13,9 @@ All Rights Reserved.
 
 namespace dungeon
 {
-	/*
-	重み付き抽選
-	*/
+	/**
+	 * 重み付き抽選
+	 */
 	template <class InputIterator, class Predicate>
 	InputIterator DrawLots(const std::shared_ptr<Random>& random, InputIterator first, InputIterator last, Predicate pred) noexcept
 	{
@@ -31,7 +31,6 @@ namespace dungeon
 			InputIterator mBody;
 		};
 		std::vector<Entry> weights;
-		weights.reserve(std::distance(first, last));
 		for (InputIterator i = first; i != last; ++i)
 		{
 			auto weight = pred(*i);

--- a/Source/DungeonGenerator/Private/DungeonGenerateActor.cpp
+++ b/Source/DungeonGenerator/Private/DungeonGenerateActor.cpp
@@ -390,14 +390,14 @@ float ADungeonGenerateActor::GetGridSize() const
 	return DungeonGenerateParameter && DungeonGenerateParameter->GridSize;
 }
 
-FVector ADungeonGenerateActor::GetRoomMaxSize() const
+FVector ADungeonGenerateActor::GetRoomMaxSizeWithMargin(const int32_t margin) const
 {
 	if (DungeonGenerateParameter)
 	{
 		FVector result;
-		result.X = DungeonGenerateParameter->GetRoomWidth().Max;
-		result.Y = DungeonGenerateParameter->GetRoomDepth().Max;
-		result.Z = DungeonGenerateParameter->GetRoomHeight().Max;
+		result.X = DungeonGenerateParameter->GetRoomWidth().Max + margin;
+		result.Y = DungeonGenerateParameter->GetRoomDepth().Max + margin;
+		result.Z = DungeonGenerateParameter->GetRoomHeight().Max + margin;
 		return result * DungeonGenerateParameter->GetGridSize().To3D();
 	}
 	return FVector::ZeroVector;

--- a/Source/DungeonGenerator/Private/DungeonGenerateActor.cpp
+++ b/Source/DungeonGenerator/Private/DungeonGenerateActor.cpp
@@ -39,6 +39,7 @@ ADungeonGenerateActor::ADungeonGenerateActor(const FObjectInitializer& initializ
 {
 	// Tick Enable
 	PrimaryActorTick.bCanEverTick = PrimaryActorTick.bStartWithTickEnabled = true;
+	PrimaryActorTick.TickInterval = 6.f / 60.f;
 
 	SetCanBeDamaged(false);
 }

--- a/Source/DungeonGenerator/Private/MainLevel/DungeonComponentActivatorComponent.cpp
+++ b/Source/DungeonGenerator/Private/MainLevel/DungeonComponentActivatorComponent.cpp
@@ -162,9 +162,9 @@ void UDungeonComponentActivatorComponent::TickImplement(const FVector& location)
 			if (lastDungeonPartition != currentDungeonPartition)
 			{
 #if WITH_EDITOR
-				if (GetOwner())
+				if (const auto* ownerActor = GetOwner())
 				{
-					DUNGEON_GENERATOR_VERBOSE(TEXT("Actor '%s' has been registered for partitioning"), *GetOwner()->GetName());
+					DUNGEON_GENERATOR_VERBOSE(TEXT("Actor '%s' has been registered for partitioning"), *ownerActor->GetName());
 				}
 #endif
 
@@ -191,9 +191,9 @@ void UDungeonComponentActivatorComponent::TickImplement(const FVector& location)
 void UDungeonComponentActivatorComponent::CallPartitionActivate()
 {
 #if WITH_EDITOR
-	if (GetOwner())
+	if (const auto* ownerActor = GetOwner())
 	{
-		DUNGEON_GENERATOR_VERBOSE(TEXT("Activate actor '%s"), *GetOwner()->GetName());
+		DUNGEON_GENERATOR_VERBOSE(TEXT("Activate actor '%s"), *ownerActor->GetName());
 	}
 #endif
 
@@ -238,7 +238,7 @@ void UDungeonComponentActivatorComponent::CallPartitionInactivate()
 
 		if (EnableOwnerActorAiControl)
 		{
-			if (APawn* ownerPawn = Cast<APawn>(GetOwner()))
+			if (const auto* ownerPawn = Cast<APawn>(owner))
 				SaveAndStopAiLogic(EDungeonComponentActivateReason::Partition, TEXT("DungeonActivatorComponent"), ownerPawn);
 		}
 	}
@@ -272,7 +272,7 @@ void UDungeonComponentActivatorComponent::LoadActorTickEnable(const EDungeonComp
 	const bool currentEnabled = mIsTickEnabled.all();
 	if (previousEnabled != currentEnabled)
 	{
-		if (AActor* owner = GetOwner())
+		if (auto* owner = GetOwner())
 		{
 			owner->SetActorTickEnabled(mTickSaver);
 		}
@@ -282,7 +282,7 @@ void UDungeonComponentActivatorComponent::LoadActorTickEnable(const EDungeonComp
 // Component
 void UDungeonComponentActivatorComponent::SaveAndDisableComponentActivation(const EDungeonComponentActivateReason activateReason)
 {
-	auto* owner = GetOwner();
+	const auto* owner = GetOwner();
 	if (IsValid(owner))
 		SaveAndDisableComponentActivation(activateReason, owner);
 }
@@ -333,7 +333,7 @@ void UDungeonComponentActivatorComponent::LoadComponentActivation(const EDungeon
 // Collision
 void UDungeonComponentActivatorComponent::SaveAndDisableCollisionEnable(const EDungeonComponentActivateReason activateReason)
 {
-	AActor* owner = GetOwner();
+	const auto* owner = GetOwner();
 	if (IsValid(owner))
 		SaveAndDisableCollisionEnable(activateReason, owner);
 }
@@ -387,7 +387,7 @@ void UDungeonComponentActivatorComponent::LoadCollisionEnable(const EDungeonComp
 // Visibility
 void UDungeonComponentActivatorComponent::SaveAndDisableVisibility(const EDungeonComponentActivateReason activateReason)
 {
-	AActor* owner = GetOwner();
+	const auto* owner = GetOwner();
 	if (IsValid(owner))
 		SaveAndDisableVisibility(activateReason, owner);
 }
@@ -441,7 +441,7 @@ void UDungeonComponentActivatorComponent::LoadVisibility(const EDungeonComponent
 // AI
 void UDungeonComponentActivatorComponent::SaveAndStopAiLogic(const EDungeonComponentActivateReason activateReason, const FString& reason)
 {
-	if (auto* owner = Cast<APawn>(GetOwner()))
+	if (const auto* owner = Cast<APawn>(GetOwner()))
 	{
 		if (IsValid(owner))
 			SaveAndStopAiLogic(activateReason, reason, owner);
@@ -472,7 +472,7 @@ void UDungeonComponentActivatorComponent::LoadAiLogic(const EDungeonComponentAct
 {
 	if (mLogicEnabled.set(static_cast<size_t>(activateReason)).all())
 	{
-		if (auto* owner = Cast<APawn>(GetOwner()))
+		if (const auto* owner = Cast<APawn>(GetOwner()))
 		{
 			if (auto* controller = owner->GetController<AAIController>())
 			{

--- a/Source/DungeonGenerator/Private/MainLevel/DungeonComponentActivatorComponent.cpp
+++ b/Source/DungeonGenerator/Private/MainLevel/DungeonComponentActivatorComponent.cpp
@@ -22,6 +22,9 @@ UDungeonComponentActivatorComponent::UDungeonComponentActivatorComponent(const F
 {
 	PrimaryComponentTick.bCanEverTick = true;
 	PrimaryComponentTick.bStartWithTickEnabled = true;
+
+	// GameThread以外からの呼び出しを許可
+	PrimaryComponentTick.bRunOnAnyThread = true;
 }
 
 void UDungeonComponentActivatorComponent::BeginPlay()
@@ -104,6 +107,9 @@ void UDungeonComponentActivatorComponent::EndPlay(const EEndPlayReason::Type end
 #endif
 }
 
+/*
+ * GameThread以外から呼び出されるのでスレッドセーフに注意して下さい
+ */
 void UDungeonComponentActivatorComponent::TickComponent(float deltaTime, enum ELevelTick tickType, FActorComponentTickFunction* thisTickFunction)
 {
 	Super::TickComponent(deltaTime, tickType, thisTickFunction);
@@ -143,6 +149,9 @@ void UDungeonComponentActivatorComponent::TickComponent(float deltaTime, enum EL
 #endif
 }
 
+/*
+ * GameThread以外から呼び出されるのでスレッドセーフに注意して下さい
+ */
 void UDungeonComponentActivatorComponent::TickImplement(const FVector& location)
 {
 	// ADungeonMainLevelScriptActorではないならTick不要
@@ -193,11 +202,9 @@ void UDungeonComponentActivatorComponent::CallPartitionActivate()
 #if WITH_EDITOR
 	if (const auto* ownerActor = GetOwner())
 	{
-		DUNGEON_GENERATOR_VERBOSE(TEXT("Activate actor '%s"), *ownerActor->GetName());
+		DUNGEON_GENERATOR_VERBOSE(TEXT("Activate the near component of Actor '%s'"), *ownerActor->GetName());
 	}
 #endif
-
-	OnPartitionActivate();
 
 	if (EnableComponentActivationControl)
 		LoadComponentActivation(EDungeonComponentActivateReason::Partition);
@@ -221,7 +228,7 @@ void UDungeonComponentActivatorComponent::CallPartitionInactivate()
 	if (IsValid(owner))
 	{
 #if WITH_EDITOR
-		DUNGEON_GENERATOR_VERBOSE(TEXT("Inactivate actor '%s"), *owner->GetName());
+		DUNGEON_GENERATOR_VERBOSE(TEXT("Deactivate the near component of Actor '%s'"), *owner->GetName());
 #endif
 
 		if (EnableComponentActivationControl)
@@ -242,8 +249,6 @@ void UDungeonComponentActivatorComponent::CallPartitionInactivate()
 				SaveAndStopAiLogic(EDungeonComponentActivateReason::Partition, TEXT("DungeonActivatorComponent"), ownerPawn);
 		}
 	}
-
-	OnPartitionInactivate();
 }
 
 // Actor

--- a/Source/DungeonGenerator/Private/MainLevel/DungeonPartition.cpp
+++ b/Source/DungeonGenerator/Private/MainLevel/DungeonPartition.cpp
@@ -15,12 +15,6 @@ void UDungeonPartition::RegisterActivatorComponent(UDungeonComponentActivatorCom
 			component->CallPartitionActivate();
 		else
 			component->CallPartitionInactivate();
-
-		if (mCallCastShadowActivate)
-			component->CallCastShadowActivate();
-		else
-			component->CallCastShadowInactivate();
-
 		ActivatorComponents.Emplace(component);
 	}
 }
@@ -61,38 +55,6 @@ void UDungeonPartition::CallPartitionInactivate()
 			if (IsValid(component))
 			{
 				component->CallPartitionInactivate();
-			}
-		}
-	}
-}
-
-void UDungeonPartition::CallCastShadowActivate()
-{
-	if (!mCallCastShadowActivate)
-	{
-		mCallCastShadowActivate = true;
-
-		for (UDungeonComponentActivatorComponent* component : ActivatorComponents)
-		{
-			if (IsValid(component))
-			{
-				component->CallCastShadowActivate();
-			}
-		}
-	}
-}
-
-void UDungeonPartition::CallCastShadowInactivate()
-{
-	if (mCallCastShadowActivate)
-	{
-		mCallCastShadowActivate = false;
-
-		for (UDungeonComponentActivatorComponent* component : ActivatorComponents)
-		{
-			if (IsValid(component))
-			{
-				component->CallCastShadowInactivate();
 			}
 		}
 	}

--- a/Source/DungeonGenerator/Private/SubActor/DungeonActorSpawnDirector.cpp
+++ b/Source/DungeonGenerator/Private/SubActor/DungeonActorSpawnDirector.cpp
@@ -1,0 +1,108 @@
+/**
+ * @author		Shun Moriya
+ * @copyright	2025- Shun Moriya
+ * All Rights Reserved.
+ * 
+ * A spawner class that spawns actors at regular intervals.
+ * ADungeonActorSpawnDirector provides the ability to spawn actors in the game at specified intervals.
+ * The type of actor to be spawned and the probability of its occurrence are defined by the FDungeonSpawnActorParameter structure.
+ *
+ * This class is used for spawn control with randomness and in situations where multiple types of actors are handled simultaneously.
+ * The spawn interval and parameters can be changed dynamically according to game progression or difficulty adjustment.
+ *
+ * 一定間隔でアクターをスポーンするスポナークラス。
+ * ADungeonActorSpawnDirector は、指定された間隔でゲーム内にアクターを生成する機能を提供します。
+ * スポーン対象となるアクターの種類や発生確率は、FDungeonSpawnActorParameter 構造体によって定義されます。
+ *
+ * 本クラスはランダム性を持つスポーン制御や、複数タイプのアクターを同時に扱う場面で使用されます。
+ * ゲーム進行や難易度調整に応じて、スポーン間隔やパラメータを動的に変更することも可能です。
+ */
+
+#include "SubActor/DungeonActorSpawnDirector.h"
+#include "Core/Debug/Debug.h"
+#include "Core/Helper/DrawLots.h"
+
+ADungeonActorSpawnDirector::ADungeonActorSpawnDirector(const FObjectInitializer& objectInitializer)
+    : Super(objectInitializer)
+{
+	// Tick Enable
+	PrimaryActorTick.bCanEverTick = PrimaryActorTick.bStartWithTickEnabled = true;
+	PrimaryActorTick.TickInterval = 1.f;
+
+	// ルートシーンコンポーネントを作成
+	Root = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
+	check(IsValid(Root));
+	SetRootComponent(Root);
+}
+
+void ADungeonActorSpawnDirector::BeginPlay()
+{
+	Super::BeginPlay();
+
+	// 変数を初期化
+	mElapsedTime = SpawnIntervalTime;
+	mRandom = std::make_shared<dungeon::Random>();
+
+	// サーバーでないのなら何も処理しない
+	if (HasAuthority() == false)
+	{
+		DUNGEON_GENERATOR_WARNING(TEXT("Destroy spawner '%s' because creating actors on the client may cause synchronization errors"), *GetName());
+		Destroy();
+	}
+}
+
+void ADungeonActorSpawnDirector::Tick(float DeltaSeconds)
+{
+	Super::Tick(DeltaSeconds);
+
+	// 参照先が失効していたら管理から除外する
+	{
+		const auto i = std::remove_if(mActors.begin(), mActors.end(), [](const TWeakObjectPtr<AActor>& actor)
+			{
+				return actor.IsValid() == false;
+			}
+		);
+		mActors.erase(i, mActors.end());
+	}
+
+	// インターバル時間を超えている？
+	mElapsedTime += DeltaSeconds;
+	while (mElapsedTime >= SpawnIntervalTime)
+	{
+		mElapsedTime -= SpawnIntervalTime;
+
+		// スポーンするパラメータがある？
+		if (SpawnActorParameters.Num() > 0)
+		{
+			// 管理中のアクターが最大数を超えていない？
+			if (mActors.size() < MaxSpawnedActorsInWorld)
+			{
+				if (auto* world = GetValid(GetWorld()))
+				{
+					// 抽選
+					const auto i = dungeon::DrawLots(mRandom, SpawnActorParameters.begin(), SpawnActorParameters.end(), [](const FDungeonSpawnActorParameter& parameter)
+						{
+							return parameter.Probability;
+						}
+					);
+
+					// 対象をスポーン
+					FActorSpawnParameters parameter;
+					parameter.Owner = this;
+					parameter.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButDontSpawnIfColliding;
+					auto* actor = world->SpawnActor<AActor>((*i).ActorClass, GetActorTransform(), parameter);
+					if (IsValid(actor))
+					{
+						mActors.emplace_back(actor);
+
+						// コントローラーが必要なら追加でスポーン
+						if (auto* pawn = Cast<APawn>(actor))
+						{
+							pawn->SpawnDefaultController();
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/Source/DungeonGenerator/Private/SubActor/DungeonActorSpawnDirector.cpp
+++ b/Source/DungeonGenerator/Private/SubActor/DungeonActorSpawnDirector.cpp
@@ -21,6 +21,8 @@
 #include "SubActor/DungeonActorSpawnDirector.h"
 #include "Core/Debug/Debug.h"
 #include "Core/Helper/DrawLots.h"
+#include <Engine/World.h>
+#include <GameFramework/Pawn.h>
 
 ADungeonActorSpawnDirector::ADungeonActorSpawnDirector(const FObjectInitializer& objectInitializer)
     : Super(objectInitializer)

--- a/Source/DungeonGenerator/Public/DungeonGenerateActor.h
+++ b/Source/DungeonGenerator/Public/DungeonGenerateActor.h
@@ -121,7 +121,7 @@ public:
 	 * Get the largest room size
 	 * 最も大きい部屋のサイズを取得します
 	 */
-	FVector GetRoomMaxSize() const;
+	FVector GetRoomMaxSizeWithMargin(const int32_t margin) const;
 
 	/**
 	 * Sets the culling distance for InstancedMesh

--- a/Source/DungeonGenerator/Public/MainLevel/DungeonMainLevelScriptActor.h
+++ b/Source/DungeonGenerator/Public/MainLevel/DungeonMainLevelScriptActor.h
@@ -36,7 +36,7 @@ class DUNGEONGENERATOR_API ADungeonMainLevelScriptActor : public ALevelScriptAct
 	 * Minimum distance from horizontal player to activate partition
 	 * パーティションをアクティブにする水平方向のプレイヤーからの最小距離
 	 */
-	static constexpr double PartitionHorizontalMinSize = 5.0 * 100.0;
+	static constexpr double PartitionHorizontalMinSize = 10.0 * 100.0;
 
 	/**
 	 * Maximum distance from horizontal player to activate partition
@@ -84,20 +84,12 @@ public:
 	UFUNCTION(BlueprintImplementableEvent, Category = "DungeonGenerator")
 	void OnPostDungeonGeneration(ADungeonGenerateActor* dungeonGenerateActor, const bool result);
 
-public:
 	/**
 	 * Find DungeonPartition by world location
 	 *
 	 * ワールド座標からDungeonPartitionを検索します
 	 */
 	UDungeonPartition* Find(const FVector& worldLocation) const noexcept;
-
-	/**
-	 * Get AABB Extents to determine if it is around the player
-	 * 
-	 * プレイヤー周辺と判断するためのAABBのExtentsを取得します
-	 */
-	const FVector& GetActiveExtents() const noexcept;
 
 	/**
 	 * Is load control effective?
@@ -119,12 +111,13 @@ public:
 	virtual void Tick(float deltaSeconds) override;
 
 private:
+	UDungeonPartition* Index(const size_t x, const size_t y) const noexcept;
 	const FSceneView* GetSceneView(const APlayerController* playerController) const;
 
-	void Begin();
-	void Mark(const FVector& playerLocation);
-	void Mark(const FSceneView* sceneView);
-	void End(const float deltaSeconds);
+	void Begin() const;
+	void Mark(const FVector& playerLocation) const;
+	void Mark(const FSceneView* sceneView) const;
+	void End(const float deltaSeconds) const;
 
 	/**
 	 * ポイントライトおよびスポットライトの影を落とすか制御します
@@ -135,6 +128,7 @@ private:
 	void ForceActivate();
 	void ForceInactivate();
 
+#if WITH_EDITOR
 	/**
 	 * 線分とAABBの交差判定
 	 * @param segmentStart	線分の開始位置
@@ -145,7 +139,10 @@ private:
 	 */
 	static bool TestSegmentAABB(const FVector& segmentStart, const FVector& segmentEnd, const FVector& aabbCenter, const FVector& aabbExtent);
 
-#if WITH_EDITOR
+	static void DrawFrustumLines(UWorld* world, const FVector& viewLocation, const FRotator& viewRotation,
+		float FovY, float aspect, float nearDistance, float farDistance,
+		const FColor& color, float lifeTime = 0.f, float thickness = 0.f);
+
 	void DrawDebugInformation() const;
 #endif
 
@@ -182,7 +179,7 @@ protected:
 	 * Load control effectiveness
 	 * 負荷コントロールの有効性
 	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Transient, Category = "DungeonGenerator|Debug")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DungeonGenerator")
 	bool bEnableLoadControl = true;
 
 #if WITH_EDITORONLY_DATA
@@ -192,6 +189,13 @@ protected:
 	 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Transient, Category = "DungeonGenerator|Debug")
 	bool ShowDebugInformation = false;
+
+	/**
+	 * Displays debugging information
+	 * デバッグ情報を表示します
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Transient, Category = "DungeonGenerator|Debug")
+	bool ShowFrustumInformation = false;
 #endif
 
 private:
@@ -199,12 +203,8 @@ private:
 	double mBoundingSize = PartitionHorizontalMinSize;
 	size_t mPartitionWidth = 0;
 	size_t mPartitionDepth = 0;
-	double mPartitionSize = PartitionHorizontalMinSize / 2;
-	FVector mActiveExtents;
+	double mPartitionSize = PartitionHorizontalMinSize;
+	FVector mActiveRegionExtent;
+	float mActiveViewRange = 0.f;
 	bool mLastEnableLoadControl;
 };
-
-inline const FVector& ADungeonMainLevelScriptActor::GetActiveExtents() const noexcept
-{
-	return mActiveExtents;
-}

--- a/Source/DungeonGenerator/Public/MainLevel/DungeonMainLevelScriptActor.h
+++ b/Source/DungeonGenerator/Public/MainLevel/DungeonMainLevelScriptActor.h
@@ -57,50 +57,60 @@ class DUNGEONGENERATOR_API ADungeonMainLevelScriptActor : public ALevelScriptAct
 	static constexpr double PartitionVerticalMaxSize = 100.0 * 100.0;
 
 public:
+	/**
+	 * コンストラクタ
+	 */
 	explicit ADungeonMainLevelScriptActor(const FObjectInitializer& objectInitializer);
+
+	/**
+	 * デストラクタ
+	 */
 	virtual ~ADungeonMainLevelScriptActor() override = default;
 
 public:
 	/**
 	 * Called before dungeon generation
+	 * 
 	 * ダンジョン生成前に呼ばれます
-	 * @param dungeonGenerateActor DungeonGenerateActor
 	 */
 	UFUNCTION(BlueprintImplementableEvent, Category = "DungeonGenerator")
 	void OnPreDungeonGeneration(ADungeonGenerateActor* dungeonGenerateActor);
 
 	/**
 	 * Called after dungeon generation
+	 * 
 	 * ダンジョン生成後に呼ばれます
-	 * @param dungeonGenerateActor	DungeonGenerateActor
-	 * @param result				trueならば生成成功
 	 */
 	UFUNCTION(BlueprintImplementableEvent, Category = "DungeonGenerator")
 	void OnPostDungeonGeneration(ADungeonGenerateActor* dungeonGenerateActor, const bool result);
 
 public:
 	/**
-	Find DungeonPartition by world location
-	ワールド座標からDungeonPartitionを検索します
-	*/
+	 * Find DungeonPartition by world location
+	 *
+	 * ワールド座標からDungeonPartitionを検索します
+	 */
 	UDungeonPartition* Find(const FVector& worldLocation) const noexcept;
 
 	/**
-	Get AABB Extents to determine if it is around the player
-	プレイヤー周辺と判断するためのAABBのExtentsを取得します
-	*/
+	 * Get AABB Extents to determine if it is around the player
+	 * 
+	 * プレイヤー周辺と判断するためのAABBのExtentsを取得します
+	 */
 	const FVector& GetActiveExtents() const noexcept;
 
 	/**
-	Is load control effective?
-	負荷コントロールが有効か取得します
-	*/
+	 * Is load control effective?
+	 *
+	 * 負荷コントロールが有効か取得します
+	 */
 	bool IsEnableLoadControl() const noexcept;
 
 	/**
-	Enables or disables load control
-	負荷コントロールを有効または無効にします
-	*/
+	 * Enables or disables load control
+	 *
+	 * 負荷コントロールを有効または無効にします
+	 */
 	void EnableLoadControl(const bool enable) noexcept;
 
 	// override
@@ -115,6 +125,12 @@ private:
 	void Mark(const FVector& playerLocation);
 	void Mark(const FSceneView* sceneView);
 	void End(const float deltaSeconds);
+
+	/**
+	 * ポイントライトおよびスポットライトの影を落とすか制御します
+	 */
+	void UpdateShadowCastingPointAndSpotLights();
+	void ForceActivateShadowCastingPointAndSpotLights();
 
 	void ForceActivate();
 	void ForceInactivate();
@@ -135,15 +151,37 @@ private:
 
 protected:
 	/**
-	レベル内のダンジョンパーティエーション
-	*/
+	 * レベル内のダンジョンパーティエーション
+	 */
 	UPROPERTY(Transient)
 	TArray<TObjectPtr<UDungeonPartition>> DungeonPartitions;
 
 	/**
-	Load control effectiveness
-	負荷コントロールの有効性
-	*/
+	 * Scaling factor of the range used for the activation decision.
+	 * If 1.0, the set distance is used as is.
+	 * Larger values increase the effective range, smaller values decrease it.
+	 *
+	 * アクティベーション判定に用いる範囲のスケーリング係数。
+	 * 1.0 の場合は設定された距離をそのまま使用します。
+	 * 値を大きくすると有効範囲が広がり、小さくすると狭まります。
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DungeonGenerator", meta = (ClampMin = "1"))
+	float ActivationRangeScale = 1.0f;
+
+	/**
+	 * Maximum number of point lights or spotlights casting shadows
+	 * Unlimited if 0
+	 *
+	 * ポイントライトまたはスポットライトの影を落とす最大数
+	 * 0ならば無制限
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DungeonGenerator")
+	uint8 MaxShadowCastingPointAndSpotLights = 12;
+
+	/**
+	 * Load control effectiveness
+	 * 負荷コントロールの有効性
+	 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Transient, Category = "DungeonGenerator|Debug")
 	bool bEnableLoadControl = true;
 

--- a/Source/DungeonGenerator/Public/MainLevel/DungeonPartition.h
+++ b/Source/DungeonGenerator/Public/MainLevel/DungeonPartition.h
@@ -7,6 +7,7 @@ All Rights Reserved.
 #pragma once
 #include <CoreMinimal.h>
 #include <Containers/Set.h>
+#include <functional>
 #include "DungeonPartition.generated.h"
 
 class ADungeonMainLevelScriptActor;
@@ -73,10 +74,15 @@ private:
 	void CallPartitionActivate();
 	void CallPartitionInactivate();
 
-	void CallCastShadowActivate();
-	void CallCastShadowInactivate();
-
 	bool IsEmpty() const;
+
+	void EachDungeonComponentActivatorComponent(const std::function<void(UDungeonComponentActivatorComponent*)>& function) const
+	{
+		for (const auto& dungeonComponentActivatorComponent : ActivatorComponents)
+		{
+			function(dungeonComponentActivatorComponent);
+		}
+	}
 
 protected:
 	UPROPERTY(Transient)
@@ -85,7 +91,6 @@ protected:
 private:
 	float mInactivateRemainTimer = 0.f;
 	bool mPartitionActivate = true;
-	bool mCallCastShadowActivate = true;
 	ActiveState mMarked = ActiveState::Inactivate;
 	ActiveReason mActiveStateType = ActiveReason::Unknown;
 

--- a/Source/DungeonGenerator/Public/SubActor/DungeonActorSpawnDirector.h
+++ b/Source/DungeonGenerator/Public/SubActor/DungeonActorSpawnDirector.h
@@ -1,0 +1,113 @@
+/**
+ * @author		Shun Moriya
+ * @copyright	2025- Shun Moriya
+ * All Rights Reserved.
+ */
+
+#pragma once
+#include <CoreMinimal.h>
+#include <GameFramework/Actor.h>
+#include <memory>
+#include <vector>
+#include "DungeonActorSpawnDirector.generated.h"
+
+namespace dungeon
+{
+	class Random;
+}
+
+/**
+ * A parameter structure that defines the type and probability of the actor to be spawned.
+ * FDungeonSpawnActorParameter is used by Spawner to specify the class type of the actor to be spawned and
+ * the class type of the actor to be spawned and its probability of occurrence.
+ * 
+ * スポーンするアクターの型と確率を定義するパラメータ構造体。
+ * FDungeonSpawnActorParameter は Spawner によって利用され、生成対象となるアクターのクラス型と
+ * その発生確率を指定します。
+ */
+USTRUCT(BlueprintType)
+struct FDungeonSpawnActorParameter
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, Category = "DungeonGenerator", meta = (AllowedClasses = "Actor"))
+	TObjectPtr<UClass> ActorClass = nullptr;
+
+	UPROPERTY(EditAnywhere, Category = "DungeonGenerator", meta = (ClampMin = "1"))
+	uint8 Probability = 10;
+};
+
+/**
+ * A spawner class that spawns actors at regular intervals.
+ * ADungeonActorSpawnDirector provides the ability to spawn actors in the game at specified intervals.
+ * The type of actor to be spawned and the probability of its occurrence are defined by the FDungeonSpawnActorParameter structure.
+ *
+ * This class is used for spawn control with randomness and in situations where multiple types of actors are handled simultaneously.
+ * The spawn interval and parameters can be changed dynamically according to game progression or difficulty adjustment.
+ *
+ * 一定間隔でアクターをスポーンするスポナークラス。
+ * ADungeonActorSpawnDirector は、指定された間隔でゲーム内にアクターを生成する機能を提供します。
+ * スポーン対象となるアクターの種類や発生確率は、FDungeonSpawnActorParameter 構造体によって定義されます。
+ *
+ * 本クラスはランダム性を持つスポーン制御や、複数タイプのアクターを同時に扱う場面で使用されます。
+ * ゲーム進行や難易度調整に応じて、スポーン間隔やパラメータを動的に変更することも可能です。
+ */
+UCLASS(ClassGroup = "DungeonGenerator")
+class DUNGEONGENERATOR_API ADungeonActorSpawnDirector : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	/**
+	 * コンストラクタ
+	 */
+	explicit ADungeonActorSpawnDirector(const FObjectInitializer& objectInitializer);
+
+	/**
+	 * デストラクタ
+	 */
+	virtual ~ADungeonActorSpawnDirector() override = default;
+
+
+	// overrides
+	virtual void BeginPlay() override;
+	virtual void Tick(float DeltaSeconds) override;
+
+protected:
+	/**
+	 * ルートシーンコンポーネント
+	 */
+	UPROPERTY()
+	TObjectPtr<USceneComponent> Root;
+
+	/**
+	 * Specify the class type of the actor to be generated and its probability of occurrence.
+	 * 
+	 * 生成対象となるアクターのクラス型とその発生確率を指定して下さい。
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DungeonGenerator")
+	TArray<FDungeonSpawnActorParameter> SpawnActorParameters;
+
+	/**
+	 * Interval to spawn actors
+	 *
+	 * アクターをスポーンする間隔
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DungeonGenerator", meta = (ClampMin = "1"))
+	float SpawnIntervalTime = 60.f;
+
+	/**
+	 * Maximum number of actors to spawn.
+	 * If this number is exceeded, the spawner will not spawn actors
+	 *
+	 * アクターをスポーンする最大人数
+	 * この人数を超えるとスポナーはアクターをスポーンしません
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DungeonGenerator")
+	uint8 MaxSpawnedActorsInWorld = 10;
+
+private:
+	std::shared_ptr<dungeon::Random> mRandom;
+	std::vector<TWeakObjectPtr<AActor>> mActors;
+	float mElapsedTime = 0.f;
+};


### PR DESCRIPTION
# 20250831-1.7.5 (58)
## Changes
* Enable/disable control of shadow generation in point light derived classes changed from per-partition to per-light.
* Fixed a misjudgment of the viewing cone in the determination of active partition.
* Limit the transfer method of the minimap to only the area of the change.
* Added actors that regularly spawn actors.
* Fixed several bugs

## 変更点
* ポイントライト派生クラスの影の生成の有効無効制御をパーティエーション単位からライト単位に変更
* アクティブパーティエーションの判定で視錐台の判定ミスを修正
* ミニマップの転送方法を変更範囲のみに限定
* アクターを定期的にスポーンするアクターを追加
* いくつかの不具合を修正
